### PR TITLE
Changed scripts to add trailing newlines to changelog entries

### DIFF
--- a/changelog/aggregate-entries.py
+++ b/changelog/aggregate-entries.py
@@ -19,7 +19,7 @@ for e in entries:
         variant,descr = txt.split("\n",1)
     except:
         raise Exception("Error reading "+e)
-    changes[variant].append(descr)
+    changes[variant].append(descr.rstrip())
 
 blocks = sorted(changes.items(),key=lambda i: variants.index(i[0]) if i[0] in variants else -1)
 

--- a/changelog/mk-entry.py
+++ b/changelog/mk-entry.py
@@ -29,4 +29,4 @@ timestamp = time.strftime("%Y-%M-%d_T%H:%M:%S")
 fname = f"{timestamp}_{variant}_{title}"
 print("Storing to",fname)
 with open(fname,"w") as fp:
-    fp.write(variant+"\n"+description)
+    fp.write(variant+"\n"+description+"\n")


### PR DESCRIPTION

The entries get an extra newline at the end, which is stripped away again when aggregating the entries.