### PR TITLE
Made Haskell code compatible with older GHC version/stack resolver

### DIFF
--- a/changelog/2026-31-12_T16:31:33_FIXED_lts_fix
+++ b/changelog/2026-31-12_T16:31:33_FIXED_lts_fix
@@ -1,0 +1,2 @@
+FIXED
+Made the code compatible with the stack LTS-23.28 resolver (GHC 9.8.4).

--- a/shockwaves/src/Clash/Shockwaves/Internal/TH/Waveform.hs
+++ b/shockwaves/src/Clash/Shockwaves/Internal/TH/Waveform.hs
@@ -23,7 +23,7 @@ deriveWaveformTuples minSize maxSize = do
   return $ flip map [minSize .. maxSize] $ \tupleNum ->
     let names = take tupleNum allNames
         vs = map VarT names
-        tuple = foldl' AppT (TupleT tupleNum) vs
+        tuple = foldl AppT (TupleT tupleNum) vs
 
         context = map (waveform `AppT`) vs
         instTy = AppT waveform tuple


### PR DESCRIPTION
Changed `fold'` to `foldl`, since this required an import only on older versions, generating either an error (missing import) or warning (redundant import) on the other version.

With this change, the code should work with GHC 9.8.4 and GHC 9.10.3 (stack resolver versions 23.28 and 24.31).