### PR TITLE
Hackage fixes

### DIFF
--- a/clash-shockwaves/clash-shockwaves.cabal
+++ b/clash-shockwaves/clash-shockwaves.cabal
@@ -16,11 +16,15 @@ category:            Hardware
 flag large-tuples
   description:
     Generate instances for `Waveform` for tuples up to the GHC imposed maximum.
+
   default: False
   manual: True
 
 common common-options
   default-extensions:
+    -- TemplateHaskell is used to support convenience functions such as
+    -- 'listToVecTH' and 'bLit'.
+    -- Prelude isn't imported by default as Clash offers Clash.Prelude
     BangPatterns
     BinaryLiterals
     ConstraintKinds
@@ -39,42 +43,27 @@ common common-options
     KindSignatures
     LambdaCase
     NamedFieldPuns
+    NoImplicitPrelude
     NoStarIsType
     PolyKinds
+    QuasiQuotes
     RankNTypes
     RecordWildCards
     ScopedTypeVariables
     StandaloneDeriving
+    TemplateHaskell
     TupleSections
     TypeApplications
     TypeFamilies
     TypeOperators
     ViewPatterns
 
-    -- TemplateHaskell is used to support convenience functions such as
-    -- 'listToVecTH' and 'bLit'.
-    TemplateHaskell
-    QuasiQuotes
-
-    -- Prelude isn't imported by default as Clash offers Clash.Prelude
-    NoImplicitPrelude
   ghc-options:
-    -Wall -Wcompat
-    -haddock
-
     -- Plugins to support type-level constraint solving on naturals
-    -fplugin GHC.TypeLits.Extra.Solver
-    -fplugin GHC.TypeLits.Normalise
-    -fplugin GHC.TypeLits.KnownNat.Solver
-
     -- Clash needs access to the source code in compiled modules
-    -fexpose-all-unfoldings
-
     -- Worker wrappers introduce unstable names for functions that might have
     -- blackboxes attached for them. You can disable this, but be sure to add
     -- a no-specialize pragma to every function with a blackbox.
-    -fno-worker-wrapper
-
     -- Strict annotations - while sometimes preventing space leaks - trigger
     -- optimizations Clash can't deal with. See:
     --
@@ -82,60 +71,72 @@ common common-options
     --
     -- These flags disables these optimizations. Note that the fields will
     -- remain strict.
+    -Wall
+    -Wcompat
+    -haddock
+    -fplugin
+    GHC.TypeLits.Extra.Solver
+    -fplugin
+    GHC.TypeLits.Normalise
+    -fplugin
+    GHC.TypeLits.KnownNat.Solver
+    -fexpose-all-unfoldings
+    -fno-worker-wrapper
     -fno-unbox-small-strict-fields
     -fno-unbox-strict-fields
+
   build-depends:
-    base,
-    Cabal,
-
-    containers,
-
-    time,
-    binary,
-    bytestring,
-    text,
-    deepseq,
-    aeson,
-    colour,
-    filepath,
-    split,
-    extra,
-    integer-logarithms,
-    data-default,
-    template-haskell,
+    aeson                         <2.3,
+    base                          >=4.18 && <5,
+    binary                        >=0.8.5 && <0.11,
+    bytestring                    >=0.10.8 && <0.13,
+    Cabal                         <3.17,
+    colour                        <2.4,
+    containers                    >=0.4.0 && <0.8,
+    data-default                  >=0.7 && <0.9,
+    deepseq                       >=1.4.1.0 && <1.6,
+    extra                         >=1.6.17 && <1.9,
+    filepath                      <1.6,
+    integer-logarithms            <1.1,
+    split                         <0.3,
+    template-haskell              >=2.20 && <2.25,
+    text                          >=0.11.3.1 && <2.2,
+    time                          >=1.8 && <1.15,
 
     -- clash-prelude will set suitable version bounds for the plugins
-    clash-prelude >= 1.8.2 && < 1.10,
-    ghc-typelits-natnormalise,
+    clash-prelude                 >=1.8.2 && <1.10,
     ghc-typelits-extra,
-    ghc-typelits-knownnat
-
+    ghc-typelits-knownnat,
+    ghc-typelits-natnormalise,
 
 library
   import: common-options
   cpp-options: -DCABAL
+
   if flag(large-tuples)
-    CPP-Options: -DLARGE_TUPLES
+    cpp-options: -DLARGE_TUPLES
   hs-source-dirs: src
   exposed-modules:
-    Paths_clash_shockwaves
     Clash.Shockwaves
-    Clash.Shockwaves.Waveform
+    Clash.Shockwaves.BitList
+    Clash.Shockwaves.Internal.BitList
+    Clash.Shockwaves.Internal.TH.Waveform
+    Clash.Shockwaves.Internal.Trace.CRE
+    Clash.Shockwaves.Internal.Translator
+    Clash.Shockwaves.Internal.Types
+    Clash.Shockwaves.Internal.Util
+    Clash.Shockwaves.Internal.Waveform
     Clash.Shockwaves.LUT
     Clash.Shockwaves.Style
     Clash.Shockwaves.Style.Colors
     Clash.Shockwaves.Trace
     Clash.Shockwaves.Trace.CRE
-    Clash.Shockwaves.BitList
-    Clash.Shockwaves.Internal.Types
-    Clash.Shockwaves.Internal.Waveform
-    Clash.Shockwaves.Internal.BitList
-    Clash.Shockwaves.Internal.Translator
-    Clash.Shockwaves.Internal.Util
-    Clash.Shockwaves.Internal.Trace.CRE
-    Clash.Shockwaves.Internal.TH.Waveform
+    Clash.Shockwaves.Waveform
+    Paths_clash_shockwaves
+
   autogen-modules:
     Paths_clash_shockwaves
+
   default-language: Haskell2010
 
 -- Run a bunch of tests about translators and translations
@@ -149,11 +150,12 @@ test-suite test-library
   other-modules:
     Tests.Structure
     Tests.Types
+
   build-depends:
     clash-shockwaves,
-    tasty >= 1.2 && < 1.6,
+    tasty >=1.2 && <1.6,
     tasty-hunit,
-    tasty-th
+    tasty-th,
 
 -- Produce a VCD output of many different types to check in Surfer / use to test Surfer
 test-suite test-vcd
@@ -165,6 +167,7 @@ test-suite test-vcd
   main-is: vcd.hs
   other-modules:
     Tests.Types
+
   build-depends:
     clash-shockwaves,
-    directory
+    directory,

--- a/clash-shockwaves/clash-shockwaves.cabal
+++ b/clash-shockwaves/clash-shockwaves.cabal
@@ -6,7 +6,7 @@ license-file:        LICENSE
 copyright:           Copyright © 2026 QBayLogic B.V.
 author:              Marijn Adriaanse <marijn@qbaylogic.com>
 maintainer:          QBayLogic B.V. <devops@qbaylogic.com>
-synopsis:            Typed waveforms for Clash
+synopsis:            Typed waveforms for Clash using the Surfer waveform viewer
 description:         A library for creating typed waveforms.
                      The library allows the user to specify what the waveforms
                      for a data type should look like, and includes tools for

--- a/clash-shockwaves/clash-shockwaves.cabal
+++ b/clash-shockwaves/clash-shockwaves.cabal
@@ -2,8 +2,16 @@ cabal-version:       2.4
 name:                clash-shockwaves
 version:             0.0.0
 license:             BSD-2-Clause
+license-file:        LICENSE
+copyright:           Copyright © 2026 QBayLogic B.V.
 author:              Marijn Adriaanse <marijn@qbaylogic.com>
 maintainer:          QBayLogic B.V. <devops@qbaylogic.com>
+synopsis:            Typed waveforms for Clash
+description:         A library for creating typed waveforms.
+                     The library allows the user to specify what the waveforms
+                     for a data type should look like, and includes tools for
+                     storing this metadata in simulations.
+category:            Hardware
 
 flag large-tuples
   description:
@@ -126,6 +134,8 @@ library
     Clash.Shockwaves.Internal.Util
     Clash.Shockwaves.Internal.Trace.CRE
     Clash.Shockwaves.Internal.TH.Waveform
+  autogen-modules:
+    Paths_clash_shockwaves
   default-language: Haskell2010
 
 -- Run a bunch of tests about translators and translations

--- a/clash-shockwaves/clash-shockwaves.cabal
+++ b/clash-shockwaves/clash-shockwaves.cabal
@@ -22,9 +22,6 @@ flag large-tuples
 
 common common-options
   default-extensions:
-    -- TemplateHaskell is used to support convenience functions such as
-    -- 'listToVecTH' and 'bLit'.
-    -- Prelude isn't imported by default as Clash offers Clash.Prelude
     BangPatterns
     BinaryLiterals
     ConstraintKinds
@@ -43,7 +40,6 @@ common common-options
     KindSignatures
     LambdaCase
     NamedFieldPuns
-    NoImplicitPrelude
     NoStarIsType
     PolyKinds
     QuasiQuotes
@@ -51,19 +47,36 @@ common common-options
     RecordWildCards
     ScopedTypeVariables
     StandaloneDeriving
-    TemplateHaskell
     TupleSections
     TypeApplications
     TypeFamilies
     TypeOperators
     ViewPatterns
 
+    -- TemplateHaskell is used to support convenience functions such as
+    -- 'listToVecTH' and 'bLit'.
+    TemplateHaskell
+
+    -- Prelude isn't imported by default as Clash offers Clash.Prelude
+    NoImplicitPrelude
+
   ghc-options:
+    -Wall -Wcompat
+    -haddock
+
     -- Plugins to support type-level constraint solving on naturals
+    -fplugin GHC.TypeLits.Extra.Solver
+    -fplugin GHC.TypeLits.Normalise
+    -fplugin GHC.TypeLits.KnownNat.Solver
+
     -- Clash needs access to the source code in compiled modules
+    -fexpose-all-unfoldings
+
     -- Worker wrappers introduce unstable names for functions that might have
     -- blackboxes attached for them. You can disable this, but be sure to add
     -- a no-specialize pragma to every function with a blackbox.
+    -fno-worker-wrapper
+
     -- Strict annotations - while sometimes preventing space leaks - trigger
     -- optimizations Clash can't deal with. See:
     --
@@ -71,17 +84,6 @@ common common-options
     --
     -- These flags disables these optimizations. Note that the fields will
     -- remain strict.
-    -Wall
-    -Wcompat
-    -haddock
-    -fplugin
-    GHC.TypeLits.Extra.Solver
-    -fplugin
-    GHC.TypeLits.Normalise
-    -fplugin
-    GHC.TypeLits.KnownNat.Solver
-    -fexpose-all-unfoldings
-    -fno-worker-wrapper
     -fno-unbox-small-strict-fields
     -fno-unbox-strict-fields
 
@@ -153,7 +155,7 @@ test-suite test-library
 
   build-depends:
     clash-shockwaves,
-    tasty >=1.2 && <1.6,
+    tasty                         >=1.2 && <1.6,
     tasty-hunit,
     tasty-th,
 


### PR DESCRIPTION
Added missing fields, and set dependency ranges / upper limits for dependencies.
`cabal check` now only gives warnings about `ghc-typelits-*` not having dependency ranges, which is intentional as these are set by Clash.