### PR TITLE
Add a pipeline for checking changelog entries have been added

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -15,6 +15,7 @@ jobs:
           fetch-depth: 0  # needed to diff properly
 
       - name: Check for changelog entry
+        continue-on-error: true
         run: |
           # Compare PR branch against main
           BASE_REF="origin/${{ github.base_ref }}"
@@ -26,6 +27,7 @@ jobs:
 
           if [ -z "$added" ]; then
             echo "::warning title=Missing changelog entry::No new file added to changelog/"
+            exit 1
           else
             echo "Changelog entries found:"
             echo "$added"

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -15,7 +15,6 @@ jobs:
           fetch-depth: 0  # needed to diff properly
 
       - name: Check for changelog entry
-        continue-on-error: true
         run: |
           # Compare PR branch against main
           BASE_REF="origin/${{ github.base_ref }}"

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,32 @@
+name: changelog-check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed to diff properly
+
+      - name: Check for changelog entry
+        run: |
+          # Compare PR branch against main
+          BASE_REF="origin/${{ github.base_ref }}"
+
+          git fetch origin "${{ github.base_ref }}"
+
+          # List added files in changelog directory
+          added=$(git diff --name-status "$BASE_REF"...HEAD | grep '^[A|D]' | grep '^A\s\+changelog/' || true)
+
+          if [ -z "$added" ]; then
+            echo "::warning title=Missing changelog entry::No new file added to changelog/"
+          else
+            echo "Changelog entries found:"
+            echo "$added"
+          fi


### PR DESCRIPTION
A simple check to make sure the changelog entries haven't been forgotten.
If no files have been added to the changelog dir, it emits an warning that can be ignored if not important.

If changelog files have been removed (such as in a PR for merging back changelog aggregation) it also succeeds.