### PR TITLE
Number format override

### DIFF
--- a/changelog/entries/2026-05-05_T15:08:14_number_format_override.md
+++ b/changelog/entries/2026-05-05_T15:08:14_number_format_override.md
@@ -1,0 +1,6 @@
+---
+issues: [115]
+---
+
+# ADDED
+Added the configuration option `override_number_format` to the Surfer extension, which lets you set the format of all numbers.

--- a/docs/howto/CONFIG.md
+++ b/docs/howto/CONFIG.md
@@ -43,15 +43,29 @@ propagate_errors = false
 ```
 
 
-### NUMBER SPACER SETTINGS
+### NUMBER FORMAT AND SPACER SETTINGS
 
-You may run into a situation where the default number spacers do not suit your needs,
+You may run into a situation where the default number format or spacers do not suit your needs,
 particularly when using a predefined numerical type.
-In this case, you can override the spacers used for numbers. This can be done
-per number format.
+In this case, you can override the format and spacers used for numbers.
+The latter can be done per number format.
+
+To override the number format for all numbers, use:
+```
+override_number_format = 'S'
+```
+Options are `S`/`Sig`, `U`/`Uns`, `H`/`Hex`, `O`/`Oct`, `B`/`Bin`.
+Keep in mind that overriding the number format may result int
+
+**Note:** Overriding the format resets the spacer options; you can still use the method
+described below to get back the spacers.
+
+**Note:** The signed translator requires a separate operator precedence value for
+negative numbers. When simply using `"S"` as value, the precedence is set to 11 (not the Haskell default).
+If you want, you can set it to `{"S":6}` for a more accurate Haskell representation.
 
 
-For example, if you want unsigned numbers to be separated by `'` insted of `_`, write:
+If you want unsigned numbers to be separated by `'` insted of `_`, write:
 ```
 override_uns_spacer = [3,"'"]
 ```

--- a/docs/howto/CONFIG.md
+++ b/docs/howto/CONFIG.md
@@ -55,15 +55,10 @@ To override the number format for all numbers, use:
 override_number_format = 'S'
 ```
 Options are `S`/`Sig`, `U`/`Uns`, `H`/`Hex`, `O`/`Oct`, `B`/`Bin`.
-Keep in mind that overriding the number format may result int
+Keep in mind that this will produce values that no longer match Haskell.
 
-**Note:** Overriding the format resets the spacer options; you can still use the method
-described below to get back the spacers.
-
-**Note:** The signed translator requires a separate operator precedence value for
-negative numbers. When simply using `"S"` as value, the precedence is set to 11 (not the Haskell default).
-If you want, you can set it to `{"S":6}` for a more accurate Haskell representation.
-
+> **Note:** Overriding the format resets the spacer options; you can still use the method
+> described below to get back the spacers.
 
 If you want unsigned numbers to be separated by `'` insted of `_`, write:
 ```

--- a/docs/howto/NUMBER.md
+++ b/docs/howto/NUMBER.md
@@ -40,7 +40,7 @@ Some default spacers are defined. `NoSpacer` is the same as `'Nothing`.
 `DecSpacer` is the default for decimal numbers and places a `_` every 3 digits;
 `BinSpacer`, `OctSpacer` and `HexSpacer` place a `_` every 8, 4 and 2 digits respectively.
 
-**Note:** The spacer configuration can be overridden globally per number format!
+**Note:** The number format, as well as the spacer configuration per number format, can be overridden globally!
 Check [the configuration guide](CONFIG.md) for more.
 
 ### More control

--- a/docs/howto/config/shockwaves.toml
+++ b/docs/howto/config/shockwaves.toml
@@ -13,8 +13,9 @@
 # propagate_errors = false
 
 ### The default number format can be changed for all number translators.
-### For the signed format, you can set the operator precedence of negative values.
-# override_number_format = {"Sig"=6} # using just "Sig" defaults to precedence 11
+### This removes all spacers and sets the prefix to `<x>:` where `<x>` is the first
+### letter of the format.
+# override_number_format = "Sig"
 # override_number_format = "Uns"
 # override_number_format = "Hex"
 # override_number_format = "Oct"

--- a/docs/howto/config/shockwaves.toml
+++ b/docs/howto/config/shockwaves.toml
@@ -12,6 +12,14 @@
 ### This behaviour can be turned off:
 # propagate_errors = false
 
+### The default number format can be changed for all number translators.
+### For the signed format, you can set the operator precedence of negative values.
+# override_number_format = {"Sig"=6} # using just "Sig" defaults to precedence 11
+# override_number_format = "Uns"
+# override_number_format = "Hex"
+# override_number_format = "Oct"
+# override_number_format = "Bin"
+
 ### Numbers are rendered using spacers to make them more legible.
 ### These can be specified from within Haskell, but this behaviour may be
 ### overwritten per number type. By default, signed and unsigned decimal

--- a/surfer-shockwaves/src/config.rs
+++ b/surfer-shockwaves/src/config.rs
@@ -8,7 +8,7 @@ use either::Either;
 use either::Either::*;
 use extism_pdk::{error, info, warn};
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use toml::{Table, Value as TVal};
 
 use camino::Utf8PathBuf;
@@ -34,11 +34,13 @@ pub struct Config {
 type StyleMap = HashMap<String, Either<Option<WaveStyle>, toml::Value>>;
 
 /// A single configuration file
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default)]
 pub struct Configuration {
     #[serde(default)]
     pub propagate_errors: Option<bool>,
 
+    #[serde(default)]
+    pub override_number_format: Option<NumberFormat>,
     #[serde(default)]
     pub override_sig_spacer: Option<NumberSpacer>,
     #[serde(default)]
@@ -207,6 +209,14 @@ impl Config {
         self.local
             .propagate_errors
             .unwrap_or(self.global.propagate_errors.unwrap_or(true))
+    }
+
+    /// Get the number formar override settings.
+    pub fn get_format_override(&self) -> Option<&NumberFormat> {
+        self.local
+            .override_number_format
+            .as_ref()
+            .or(self.global.override_number_format.as_ref())
     }
 
     /// Get the spacer override settings for a number format.

--- a/surfer-shockwaves/src/data.rs
+++ b/surfer-shockwaves/src/data.rs
@@ -136,11 +136,11 @@ pub enum TranslatorVariant {
     Number {
         #[serde(alias = "f")]
         format: NumberFormat,
-        #[serde(alias = "s")]
+        #[serde(alias = "s", default)]
         spacer: NumberSpacer,
-        #[serde(alias = "p")]
+        #[serde(alias = "p", default)]
         prefix: String,
-        #[serde(alias = "w")]
+        #[serde(alias = "w", default)]
         warn: bool,
     },
 

--- a/surfer-shockwaves/src/data.rs
+++ b/surfer-shockwaves/src/data.rs
@@ -1,7 +1,8 @@
 //! All types for VCD Metadata (translators, signals, and LUTs)
 
 use egui::Color32;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::de::{Deserializer, IntoDeserializer};
 use std::collections::HashMap;
 
 pub type SigMap = HashMap<String, String>;
@@ -14,7 +15,7 @@ pub type Lut = HashMap<String, Translation>;
 /// - the type of each signal
 /// - the translator of each type
 /// - any LUTs needed for translation
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Data {
     pub signals: SigMap,
     pub types: TypeMap,
@@ -22,7 +23,7 @@ pub struct Data {
 }
 
 /// The complete translation, including any subsignals, of a binary value.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Translation(pub Render, pub Vec<(String, Translation)>);
 
 /// The visual representation of the value on a single waveform line.
@@ -30,7 +31,7 @@ pub type Render = Option<(Value, WaveStyle, Prec)>;
 pub type Value = String;
 
 /// The style (which determine the color of the waveform).
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum WaveStyle {
     #[serde(alias = "D")]
     Default,
@@ -64,9 +65,10 @@ pub enum WaveStyle {
 pub type Prec = i16;
 /// Precedence of an atomic (a number, an identifier, somthing between parentheses)
 pub const ATOMIC: Prec = 11;
+pub const DEFAULT_SIG_NEG_PREC: Prec = ATOMIC; // not the haskell default of 6!
 
 /// A construct for turning binary values into translations.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Translator {
     #[serde(alias = "w")]
     pub width: u32,
@@ -76,7 +78,7 @@ pub struct Translator {
 }
 
 /// The different types of translators
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub enum TranslatorVariant {
     #[serde(alias = "R")]
     Ref(String),
@@ -176,7 +178,7 @@ pub enum TranslatorVariant {
 }
 
 /// A part of a value (for `AdvancedProduct`).
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum ValuePart {
     #[serde(alias = "L")]
     Lit(String),
@@ -185,7 +187,7 @@ pub enum ValuePart {
 }
 
 /// A transformation on a binary value (for `ChangeBits`).
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum BitPart {
     #[serde(alias = "I")]
     In,
@@ -198,7 +200,8 @@ pub enum BitPart {
 }
 
 /// A number format (integers only).
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Deserialize, Debug, Clone, Copy)]
+#[serde(remote = "NumberFormat")]
 pub enum NumberFormat {
     #[serde(alias = "S")]
     Sig(Prec),
@@ -211,11 +214,24 @@ pub enum NumberFormat {
     #[serde(alias = "B")]
     Bin,
 }
+impl<'de> Deserialize<'de> for NumberFormat {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s == "Sig" || s == "S" {
+            Ok(NumberFormat::Sig(DEFAULT_SIG_NEG_PREC))
+        } else {
+            NumberFormat::deserialize(s.into_deserializer())
+        }
+    }
+}
 
 /// What spacer, if any, to use, to make large numbers more legible.
 pub type NumberSpacer = Option<(u32, String)>;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Structure(pub Vec<(String, Structure)>);
 
 impl Data {

--- a/surfer-shockwaves/src/translate.rs
+++ b/surfer-shockwaves/src/translate.rs
@@ -43,7 +43,7 @@ fn translate_number(
     value: &str,
     format: &NumberFormat,
     spacer: &NumberSpacer,
-    prefix: &String,
+    prefix: &str,
     warn: bool,
 ) -> Translation {
     let apply_spacer = |v: String| match spacer {
@@ -167,6 +167,18 @@ fn translate_number(
         }),
         vec![],
     )
+}
+
+impl NumberFormat {
+    fn default_prefix(&self) -> &str {
+        match self {
+            NumberFormat::Sig(_) => "S:",
+            NumberFormat::Uns => "U:",
+            NumberFormat::Hex => "H:",
+            NumberFormat::Oct => "O:",
+            NumberFormat::Bin => "B:",
+        }
+    }
 }
 
 impl ValuePart {
@@ -357,11 +369,11 @@ impl State {
                 prefix,
                 warn,
             } => {
-                let (format, spacer) = self
+                let (format, spacer, prefix) = self
                     .config
                     .get_format_override()
-                    .map(|f| (f, &None))
-                    .unwrap_or((format, spacer));
+                    .map(|f| (f, &None, f.default_prefix()))
+                    .unwrap_or((format, spacer, prefix));
                 let spacer = self.config.get_spacer_override(format).unwrap_or(spacer);
                 translate_number(value, format, spacer, prefix, *warn)
             }

--- a/surfer-shockwaves/src/translate.rs
+++ b/surfer-shockwaves/src/translate.rs
@@ -357,6 +357,11 @@ impl State {
                 prefix,
                 warn,
             } => {
+                let (format, spacer) = self
+                    .config
+                    .get_format_override()
+                    .map(|f| (f, &None))
+                    .unwrap_or((format, spacer));
                 let spacer = self.config.get_spacer_override(format).unwrap_or(spacer);
                 translate_number(value, format, spacer, prefix, *warn)
             }


### PR DESCRIPTION
Someone asked how they could change the number format, and it turns out I forgot to add a config feature for that.
It is now possible though `override_number_format`. Numbers are then displayed like `B:010x0` or `S:-234`, to differentiate them from the normal formats.

Fixes #115 