### PR TITLE
No proxy no width

### DIFF
--- a/changelog/entries/2026-05-19_T16:47:19_no_proxy.md
+++ b/changelog/entries/2026-05-19_T16:47:19_no_proxy.md
@@ -1,0 +1,10 @@
+---
+issues: [111]
+---
+
+# CHANGED
+The functions `tRef`, `tLut` (and the new `tStaticLut` and `tGeneratedLut`) no longer take proxy arguments.
+
+# ADDED
+`defaultTypeName` derives a unique name automatically for a type.
+The name consists of the simple type name plus a hash to prevent name collisions.

--- a/changelog/entries/2026-05-19_T17:24:51_no_width.md
+++ b/changelog/entries/2026-05-19_T17:24:51_no_width.md
@@ -1,0 +1,10 @@
+---
+issues: []
+---
+
+# ADDED
+`bitSize` returns the number of bits based on the `BitSize` class.
+
+# DEPRECATED
+`width` has been deprecated from the `Waveform` class.
+Instead, use `bitSize`.

--- a/clash-shockwaves/src/Clash/Shockwaves/Internal/Util.hs
+++ b/clash-shockwaves/src/Clash/Shockwaves/Internal/Util.hs
@@ -51,8 +51,8 @@ writeFileJSON :: forall a. (ToJSON a) => FilePath -> a -> IO ()
 writeFileJSON = encodeFile
 
 -- | Returns the 'BitSize' of a type as a runtime 'Int'.
-bitsize :: (BitPack a) => Proxy a -> Int
-bitsize (_ :: Proxy a) = fromInteger $ natVal $ Proxy @(BitSize a)
+bitsize :: forall a. (BitPack a) => Int
+bitsize = fromInteger $ natVal $ Proxy @(BitSize a)
 
 -- | Wrap parentheses around a value.
 parenthesize :: Value -> Value
@@ -70,15 +70,15 @@ joinWith s (x : y : r) = x <> s <> joinWith s (y : r)
 joinWith _ [x] = x
 joinWith _ [] = ""
 
-{- | Obtain the name of a type from a proxy value.
+{- | Obtain the default name of a type.
 The name consists of a unique fingerprint (which is safe to use)
 and a human readable representation of the type (which may not be unique
 if multiple sources define the same types).
 -}
-typeNameP :: (Typeable a) => Proxy a -> TypeName
-typeNameP p = show (typeRepFingerprint r) <> ":" <> show r
+defaultTypeName :: forall a. (Typeable a) => TypeName
+defaultTypeName = show (typeRepFingerprint r) <> ":" <> show r
  where
-  r = typeRep p
+  r = typeRep (Proxy @a)
 
 -- | Shorthand function for obtaining the runtime 'String' of a type level Symbol.
 sym :: forall s. (KnownSymbol s) => String

--- a/clash-shockwaves/src/Clash/Shockwaves/Internal/Util.hs
+++ b/clash-shockwaves/src/Clash/Shockwaves/Internal/Util.hs
@@ -51,8 +51,8 @@ writeFileJSON :: forall a. (ToJSON a) => FilePath -> a -> IO ()
 writeFileJSON = encodeFile
 
 -- | Returns the 'BitSize' of a type as a runtime 'Int'.
-bitsize :: forall a. (BitPack a) => Int
-bitsize = fromInteger $ natVal $ Proxy @(BitSize a)
+bitSize :: forall a. (BitPack a) => Int
+bitSize = fromInteger $ natVal $ Proxy @(BitSize a)
 
 -- | Wrap parentheses around a value.
 parenthesize :: Value -> Value

--- a/clash-shockwaves/src/Clash/Shockwaves/Internal/Waveform.hs
+++ b/clash-shockwaves/src/Clash/Shockwaves/Internal/Waveform.hs
@@ -110,8 +110,8 @@ tDup :: SubSignal -> Translator -> Translator
 tDup name (Translator w t) = Translator w $ TDuplicate name (Translator w t)
 
 -- | Generate a translator reference for a type.
-tRef :: (Waveform a) => Proxy a -> Translator
-tRef (_ :: Proxy a) =
+tRef :: forall a. (Waveform a) => Translator
+tRef =
   Translator (width @a)
     $ TRef
       (typeName @a)
@@ -128,14 +128,14 @@ tConst r = Translator 0 $ TConst $ Translation r []
 {- | Create a LUT translator for a type, using either the static LUT or the translation
 function specified in 'WaveformLUT'
 -}
-tLut :: forall a. (Waveform a, WaveformLUT a) => Proxy a -> Maybe LUT -> Translator
-tLut p l = case l of
-  Just lut -> tStaticLut p lut
-  Nothing -> tGeneratedLut p
+tLut :: forall a. (Waveform a, WaveformLUT a) => Maybe LUT -> Translator
+tLut l = case l of
+  Just lut -> tStaticLut @a lut
+  Nothing -> tGeneratedLut @a
 
 -- | Create a LUT translator for a type, using the translation function of 'WaveformLUT'.
-tGeneratedLut :: forall a. (Waveform a, WaveformLUT a) => Proxy a -> Translator
-tGeneratedLut _ =
+tGeneratedLut :: forall a. (Waveform a, WaveformLUT a) => Translator
+tGeneratedLut =
   Translator (width @a)
     $ TLut
       (typeName @a)
@@ -147,8 +147,8 @@ tGeneratedLut _ =
         }
 
 -- | Create a LUT translator for a type, using the static LUT in 'WaveformLUT'.
-tStaticLut :: forall a. (Waveform a, WaveformLUT a) => Proxy a -> LUT -> Translator
-tStaticLut _ lut =
+tStaticLut :: forall a. (Waveform a, WaveformLUT a) => LUT -> Translator
+tStaticLut lut =
   Translator (width @a)
     $ TLut
       (typeName @a)
@@ -179,7 +179,7 @@ class (Typeable a, BitPack a) => Waveform a where
   Overriding this value is only really useful for derive via strategies.
   -}
   typeName :: TypeName
-  typeName = typeNameP (Proxy @a)
+  typeName = defaultTypeName @a
 
   -- | The translator used for the data type. Must match the structure value.
   translator :: Translator
@@ -198,7 +198,7 @@ class (Typeable a, BitPack a) => Waveform a where
 
   -- | Runtime bitsize of the type.
   width :: Int
-  width = bitsize (Proxy @a)
+  width = bitsize @a
 
 {- | Return the default translator that is derived for a data type.
 This default can be modified to obtain a slightly different translator.
@@ -223,7 +223,7 @@ translateBin = translateBinT (translator @a)
 
 -- | Register this type and all its subtypes.
 addTypes :: forall a. (Waveform a) => TypeMap -> TypeMap
-addTypes = addTypesT $ tRef (Proxy @a)
+addTypes = addTypesT $ tRef @a
 
 -- | Helper function that fills the 'styles' list with 'WSDefault'.
 styles' :: forall a. (Waveform a) => [WaveStyle]
@@ -525,7 +525,7 @@ instance
   where
   translatorG = undefined
   constrTranslatorsG = undefined
-  fieldTranslatorsG = [(sym @name, tRef (Proxy @t))]
+  fieldTranslatorsG = [(sym @name, tRef @t)]
 
   widthG = width @t
 
@@ -536,7 +536,7 @@ instance
 instance (Waveform t) => WaveformG (S1 (MetaSel Nothing p q r) (Rec0 t) k) where
   translatorG = undefined
   constrTranslatorsG = undefined
-  fieldTranslatorsG = [("", tRef (Proxy @t))]
+  fieldTranslatorsG = [("", tRef @t)]
 
   widthG = width @t
 
@@ -673,9 +673,9 @@ instance
   (Waveform a, WaveformLUT a, BitPack a, Typeable a) =>
   Waveform (WaveformForLUT a)
   where
-  typeName = typeNameP (Proxy @a)
+  typeName = defaultTypeName @a
 
-  translator = tLut (Proxy @a) (staticLutL @a)
+  translator = tLut @a (staticLutL @a)
 
 ----------------------------------------------- PREC ----------------------------------
 
@@ -769,8 +769,8 @@ instance
   (WaveformConst a, BitPack a, Typeable a) =>
   Waveform (WaveformForConst a)
   where
-  typeName = typeNameP (Proxy @a)
-  translator = Translator (bitsize $ Proxy @a) $ TConst $ constTrans @a
+  typeName = defaultTypeName @a
+  translator = Translator (bitsize @a) $ TConst $ constTrans @a
 
 -- NUMBERS
 
@@ -799,7 +799,7 @@ instance
   ) =>
   Waveform (WaveformForNumber (f :: NumberFormat) (s :: Maybe NSPair) a)
   where
-  typeName = typeNameP (Proxy @a)
+  typeName = defaultTypeName @a
   translator =
     Translator (width @(WaveformForNumber f s a))
       $ TNumber
@@ -936,19 +936,19 @@ instance (Waveform a) => Waveform (Identity a)
 
 -- number wrappers
 instance (Waveform a) => Waveform (Zeroing a) where
-  translator = tDup "zeroing" $ tRef (Proxy @a)
+  translator = tDup "zeroing" $ tRef @a
 
 instance (Waveform a) => Waveform (Wrapping a) where
-  translator = tDup "wrapping" $ tRef (Proxy @a)
+  translator = tDup "wrapping" $ tRef @a
 
 instance (Waveform a) => Waveform (Saturating a) where
-  translator = tDup "saturating" $ tRef (Proxy @a)
+  translator = tDup "saturating" $ tRef @a
 
 instance (Waveform a) => Waveform (Overflowing a) where
-  translator = tDup "overflowing" $ tRef (Proxy @a)
+  translator = tDup "overflowing" $ tRef @a
 
 instance (Waveform a) => Waveform (Erroring a) where
-  translator = tDup "erroring" $ tRef (Proxy @a)
+  translator = tDup "erroring" $ tRef @a
 
 -- vectors
 instance (KnownNat n, Waveform a) => Waveform (Vec n a) where
@@ -963,7 +963,7 @@ instance (KnownNat n, Waveform a) => Waveform (Vec n a) where
             , preci = 5
             , preco = 5
             , len = fromIntegral $ natVal (Proxy @n)
-            , sub = tRef (Proxy @a)
+            , sub = tRef @a
             }
         else
           TConst $ tFromVal "Nil"
@@ -1012,14 +1012,14 @@ class WaveformRTree (isLeaf :: Bool) d a where
   translatorRTree :: Translator
 
 instance (Waveform a) => WaveformRTree True 0 a where
-  translatorRTree = tRef (Proxy @a)
+  translatorRTree = tRef @a
 
 instance
   (Waveform (RTree d1 a), Waveform a, d ~ d1 + 1, KnownNat d, KnownNat d1) =>
   WaveformRTree False d a
   where
   translatorRTree =
-    Translator (bitsize $ Proxy @(RTree d a))
+    Translator (bitsize @(RTree d a))
       $ TProduct
         { start = "<"
         , sep = ","
@@ -1030,14 +1030,14 @@ instance
         , subs = [("left", tsub), ("right", tsub)]
         }
    where
-    tsub = tRef (Proxy @(RTree d1 a))
+    tsub = tRef @(RTree d1 a)
 
 {- | A translator for displaying values with zero or more fields like tuples.
 This function will error if called for a type that has more than one constructor!
 -}
 tupleTranslator :: forall t. (BitPack t, WaveformG (Rep t ())) => Translator
 tupleTranslator =
-  Translator (bitsize (Proxy @t))
+  Translator (bitsize @t)
     $ TProduct
       { start = "("
       , sep = ","

--- a/clash-shockwaves/src/Clash/Shockwaves/Internal/Waveform.hs
+++ b/clash-shockwaves/src/Clash/Shockwaves/Internal/Waveform.hs
@@ -17,7 +17,7 @@ The 'Waveform' class, functions derived from it, special 'Waveform' variants suc
 -}
 module Clash.Shockwaves.Internal.Waveform where
 
-import Clash.Prelude
+import Clash.Prelude hiding (bitSize)
 
 import Clash.Shockwaves.BitList (BitList)
 import qualified Clash.Shockwaves.BitList as BL
@@ -112,7 +112,7 @@ tDup name (Translator w t) = Translator w $ TDuplicate name (Translator w t)
 -- | Generate a translator reference for a type.
 tRef :: forall a. (Waveform a) => Translator
 tRef =
-  Translator (width @a)
+  Translator (bitSize @a)
     $ TRef
       (typeName @a)
       TypeRef
@@ -136,7 +136,7 @@ tLut l = case l of
 -- | Create a LUT translator for a type, using the translation function of 'WaveformLUT'.
 tGeneratedLut :: forall a. (Waveform a, WaveformLUT a) => Translator
 tGeneratedLut =
-  Translator (width @a)
+  Translator (bitSize @a)
     $ TLut
       (typeName @a)
       Nothing
@@ -149,7 +149,7 @@ tGeneratedLut =
 -- | Create a LUT translator for a type, using the static LUT in 'WaveformLUT'.
 tStaticLut :: forall a. (Waveform a, WaveformLUT a) => LUT -> Translator
 tStaticLut lut =
-  Translator (width @a)
+  Translator (bitSize @a)
     $ TLut
       (typeName @a)
       (Just lut)
@@ -160,6 +160,8 @@ tStaticLut lut =
         }
 
 ------------------------------------------ WAVEFORM --------------------------------------
+
+{-# DEPRECATED width "Use bitSize instead" #-}
 
 {- |
 
@@ -196,16 +198,18 @@ class (Typeable a, BitPack a) => Waveform a where
   styles :: [WaveStyle]
   styles = []
 
-  -- | Runtime bitsize of the type.
+  {- |
+  Defines the width of the translator based on @bitSize@
+  -}
   width :: Int
-  width = bitsize @a
+  width = bitSize @a
 
 {- | Return the default translator that is derived for a data type.
 This default can be modified to obtain a slightly different translator.
 -}
 defaultTranslator ::
   forall a. (Waveform a, WaveformG (Rep a ())) => [WaveStyle] -> Translator
-defaultTranslator sty = translatorG @(Rep a ()) (width @a) (sty <> L.repeat WSDefault)
+defaultTranslator sty = translatorG @(Rep a ()) (bitSize @a) (sty <> L.repeat WSDefault)
 
 {- | Function to translate values. This function creates a translation from
 the binary representation of the data using translateBin, and the translator.
@@ -527,7 +531,7 @@ instance
   constrTranslatorsG = undefined
   fieldTranslatorsG = [(sym @name, tRef @t)]
 
-  widthG = width @t
+  widthG = bitSize @t
 
   translateWithG _ _ = undefined
   translateFieldsG x = [(sym @name, translate $ unK1 $ unM1 x)]
@@ -538,7 +542,7 @@ instance (Waveform t) => WaveformG (S1 (MetaSel Nothing p q r) (Rec0 t) k) where
   constrTranslatorsG = undefined
   fieldTranslatorsG = [("", tRef @t)]
 
-  widthG = width @t
+  widthG = bitSize @t
 
   translateWithG _ _ = undefined
   translateFieldsG x = [("", translate $ unK1 $ unM1 x)]
@@ -770,7 +774,7 @@ instance
   Waveform (WaveformForConst a)
   where
   typeName = defaultTypeName @a
-  translator = Translator (bitsize @a) $ TConst $ constTrans @a
+  translator = Translator (bitSize @a) $ TConst $ constTrans @a
 
 -- NUMBERS
 
@@ -801,7 +805,7 @@ instance
   where
   typeName = defaultTypeName @a
   translator =
-    Translator (width @(WaveformForNumber f s a))
+    Translator (bitSize @(WaveformForNumber f s a))
       $ TNumber
         { format = formatVal (Proxy @f)
         , spacer = spacerVal (Proxy @s)
@@ -953,7 +957,7 @@ instance (Waveform a) => Waveform (Erroring a) where
 -- vectors
 instance (KnownNat n, Waveform a) => Waveform (Vec n a) where
   translator =
-    Translator (width @(Vec n a))
+    Translator (bitSize @(Vec n a))
       $ if natVal (Proxy @n) /= 0
         then
           TArray
@@ -1019,7 +1023,7 @@ instance
   WaveformRTree False d a
   where
   translatorRTree =
-    Translator (bitsize @(RTree d a))
+    Translator (bitSize @(RTree d a))
       $ TProduct
         { start = "<"
         , sep = ","
@@ -1037,7 +1041,7 @@ This function will error if called for a type that has more than one constructor
 -}
 tupleTranslator :: forall t. (BitPack t, WaveformG (Rep t ())) => Translator
 tupleTranslator =
-  Translator (bitsize @t)
+  Translator (bitSize @t)
     $ TProduct
       { start = "("
       , sep = ","

--- a/clash-shockwaves/src/Clash/Shockwaves/Waveform.hs
+++ b/clash-shockwaves/src/Clash/Shockwaves/Waveform.hs
@@ -49,6 +49,7 @@ module Clash.Shockwaves.Waveform (
   -- ** Creating Translators
   defaultTranslator,
   noConstructorSubsignals,
+  defaultTypeName,
   renameFields,
   tRef,
   tDup,
@@ -61,6 +62,7 @@ module Clash.Shockwaves.Waveform (
   WaveformForNumber (..),
 ) where
 
+import Clash.Shockwaves.Internal.Util
 import Clash.Shockwaves.Internal.Translator
 import Clash.Shockwaves.Internal.Types
 

--- a/clash-shockwaves/src/Clash/Shockwaves/Waveform.hs
+++ b/clash-shockwaves/src/Clash/Shockwaves/Waveform.hs
@@ -11,7 +11,7 @@ Everything needed to create custom implementations of 'Waveform'.
 -}
 module Clash.Shockwaves.Waveform (
   -- * The Waveform class
-  Waveform (translator, styles, width),
+  Waveform (translator, styles),
   translate,
   translateBin,
   hasGeneratedLut,
@@ -48,6 +48,7 @@ module Clash.Shockwaves.Waveform (
 
   -- ** Creating Translators
   defaultTranslator,
+  bitSize,
   noConstructorSubsignals,
   defaultTypeName,
   renameFields,
@@ -62,8 +63,8 @@ module Clash.Shockwaves.Waveform (
   WaveformForNumber (..),
 ) where
 
-import Clash.Shockwaves.Internal.Util
 import Clash.Shockwaves.Internal.Translator
 import Clash.Shockwaves.Internal.Types
+import Clash.Shockwaves.Internal.Util
 
 import Clash.Shockwaves.Internal.Waveform

--- a/clash-shockwaves/tests/Tests/Types.hs
+++ b/clash-shockwaves/tests/Tests/Types.hs
@@ -4,7 +4,7 @@
 
 module Tests.Types where
 
-import Clash.Prelude
+import Clash.Prelude hiding (bitSize)
 import Clash.Shockwaves.LUT
 import Clash.Shockwaves.Waveform
 import Data.Typeable
@@ -71,10 +71,10 @@ newtype Pointer a = Pointer (Unsigned a)
 
 instance (KnownNat a) => Waveform (Pointer a) where
   translator =
-    Translator (width @(Unsigned a))
+    Translator (bitSize @(Unsigned a))
       $ TAdvancedSum
-        { index = (0, width @(Unsigned a))
-        , defTrans = Translator (width @(Unsigned a)) $ TNumber NFHex (Just (2, "_")) "0X" False
+        { index = (0, bitSize @(Unsigned a))
+        , defTrans = Translator (bitSize @(Unsigned a)) $ TNumber NFHex (Just (2, "_")) "0X" False
         , rangeTrans = [((0, 1), tConst $ Just ("NULL", WSWarn, 11))]
         }
 
@@ -82,14 +82,14 @@ newtype NumRep a = NumRep a deriving (Generic, BitPack, NFDataX, Typeable, ShowX
 
 instance (Waveform a) => Waveform (NumRep a) where
   translator =
-    Translator (width @a)
+    Translator (bitSize @a)
       $ TAdvancedProduct
         { sliceTrans =
             L.map
-              ((0, width @a),)
+              ((0, bitSize @a),)
               ( tRef @a
                   : L.map
-                    (Translator (width @a))
+                    (Translator (bitSize @a))
                     [ TNumber NFBin (Just (4, "_")) "0b" False
                     , TNumber NFOct (Just (4, "_")) "0o" False
                     , TNumber NFHex (Just (2, "_")) "0X" False
@@ -97,7 +97,7 @@ instance (Waveform a) => Waveform (NumRep a) where
                     , TNumber NFSig (Just (3, "_")) "" False
                     ]
               )
-              <> [((width @a - 1, width @a), tRef @Bool)]
+              <> [((bitSize @a - 1, bitSize @a), tRef @Bool)]
         , hierarchy =
             [("bin", 1), ("oct", 2), ("hex", 3), ("unsigned", 4), ("signed", 5), ("odd", 6)]
         , valueParts = [VPLit "{", VPRef 0 (-1), VPLit ", odd=", VPRef 6 (-1), VPLit "}"]

--- a/clash-shockwaves/tests/Tests/Types.hs
+++ b/clash-shockwaves/tests/Tests/Types.hs
@@ -87,7 +87,7 @@ instance (Waveform a) => Waveform (NumRep a) where
         { sliceTrans =
             L.map
               ((0, width @a),)
-              ( tRef (Proxy @a)
+              ( tRef @a
                   : L.map
                     (Translator (width @a))
                     [ TNumber NFBin (Just (4, "_")) "0b" False
@@ -97,7 +97,7 @@ instance (Waveform a) => Waveform (NumRep a) where
                     , TNumber NFSig (Just (3, "_")) "" False
                     ]
               )
-              <> [((width @a - 1, width @a), tRef $ Proxy @Bool)]
+              <> [((width @a - 1, width @a), tRef @Bool)]
         , hierarchy =
             [("bin", 1), ("oct", 2), ("hex", 3), ("unsigned", 4), ("signed", 5), ("odd", 6)]
         , valueParts = [VPLit "{", VPRef 0 (-1), VPLit ", odd=", VPRef 6 (-1), VPLit "}"]
@@ -131,7 +131,7 @@ instance Waveform SumStruct where
               , preci = 10
               , preco = 10
               , labels = []
-              , subs = [("sub", tRef (Proxy @(Maybe Bool)))]
+              , subs = [("sub", tRef @(Maybe Bool))]
               }
         , tDup "B" $ tConst $ Just ("SSB", WSDefault, 11)
         , Translator 2
@@ -142,7 +142,7 @@ instance Waveform SumStruct where
               , preci = 10
               , preco = 10
               , labels = []
-              , subs = [("sub", tRef (Proxy @(Either Bool Bool)))]
+              , subs = [("sub", tRef @(Either Bool Bool))]
               }
         , tDup "D" $ tConst $ Just ("SSD", WSDefault, 11)
         ]

--- a/docs/howto/ADVANCED.md
+++ b/docs/howto/ADVANCED.md
@@ -39,7 +39,7 @@ instance Waveform a => Waveform (NumRep a) where
   translator = Translator (width @a) $ TAdvancedProduct
     { sliceTrans =
       L.map ((0,width @a),)
-        ( tRef (Proxy @a) :                           -- translate as `a`
+        ( tRef @a :                                   -- translate as `a`
           L.map (Translator (width @a))               -- translate as numbers
             [ TNumber NFBin (Just (4,"_")) "0b" False
             , TNumber NFOct (Just (4,"_")) "0o" False
@@ -47,7 +47,7 @@ instance Waveform a => Waveform (NumRep a) where
             , TNumber NFUns (Just (3,"_")) "" False
             , TNumber NFSig (Just (3,"_")) "" False
             ])
-      <> [((width @a-1,width @a),tRef $ Proxy @Bool)] -- translate parity bit
+      <> [((width @a-1,width @a),tRef @Bool)] -- translate parity bit
     , hierarchy = [("bin",1),("oct",2),("hex",3),("unsigned",4),("signed",5),("odd",6)]
     , valueParts = [VPLit "{",VPRef 0 (-1),VPLit ", odd=",VPRef 6 (-1), VPLit "}"]
     , preco = 11

--- a/docs/howto/ADVANCED.md
+++ b/docs/howto/ADVANCED.md
@@ -36,18 +36,18 @@ implementation like this:
 
 ```hs
 instance Waveform a => Waveform (NumRep a) where
-  translator = Translator (width @a) $ TAdvancedProduct
+  translator = Translator (bitSize @a) $ TAdvancedProduct
     { sliceTrans =
-      L.map ((0,width @a),)
+      L.map ((0,bitSize @a),)
         ( tRef @a :                                   -- translate as `a`
-          L.map (Translator (width @a))               -- translate as numbers
+          L.map (Translator (bitSize @a))             -- translate as numbers
             [ TNumber NFBin (Just (4,"_")) "0b" False
             , TNumber NFOct (Just (4,"_")) "0o" False
             , TNumber NFHex (Just (2,"_")) "0X" False
             , TNumber NFUns (Just (3,"_")) "" False
             , TNumber NFSig (Just (3,"_")) "" False
             ])
-      <> [((width @a-1,width @a),tRef @Bool)] -- translate parity bit
+      <> [((bitSize @a-1, bitSize @a),tRef @Bool)] -- translate parity bit
     , hierarchy = [("bin",1),("oct",2),("hex",3),("unsigned",4),("signed",5),("odd",6)]
     , valueParts = [VPLit "{",VPRef 0 (-1),VPLit ", odd=",VPRef 6 (-1), VPLit "}"]
     , preco = 11
@@ -99,10 +99,10 @@ We can write a `Waveform` instance like this:
 
 ```hs
 instance KnownNat a => Waveform (Pointer a) where
-  translator = Translator (width @(Pointer a))
+  translator = Translator (bitSize @(Pointer a))
     $ TAdvancedSum
-      { index = (0,width @(Pointer a))
-      , defTrans = Translator (width @(Pointer a)) $ TNumber NFHex (Just (2,"_")) False
+      { index = (0, bitSize @(Pointer a))
+      , defTrans = Translator (bitSize @(Pointer a)) $ TNumber NFHex (Just (2,"_")) False
       , rangeTrans = [((0,1), tConst $ Just ("NULL",WSWarn,11))]
       }
 ```

--- a/docs/howto/GADTS.md
+++ b/docs/howto/GADTS.md
@@ -28,7 +28,7 @@ instance (KnownNat n, Waveform a) => Waveform (Vec n a) where
       , preci = 5
       , preco = 5
       , len = fromIntegral $ natVal (Proxy @n)
-      , sub = tRef (Proxy @a)
+      , sub = tRef @a
       }
     else
       TConst $ Translation (Just ("Nil",WSNormal,11)) []
@@ -65,7 +65,7 @@ and make them invisible (i.e. a leaf is rendered as it's containing data).
 
 ```hs
 instance (Waveform a) => WaveformRTree True 0 a where
-  translatorRTree = tRef (Proxy @a)
+  translatorRTree = tRef @a
 ```
 
 The branch translator is slightly more complex. Since `RTree` is usually rendered like
@@ -76,7 +76,7 @@ something that is impossible for the leaf nodes.
 ```hs
 instance (Waveform (RTree d1 a), Waveform a, d ~ d1 + 1, KnownNat d, KnownNat d1)
   => WaveformRTree False d a where
-  translatorRTree = Translator (bitsize $ Proxy @(RTree d a)) $ TProduct
+  translatorRTree = Translator (bitsize @(RTree d a)) $ TProduct
       { start = "<"
       , sep = ","
       , stop = ">"
@@ -85,7 +85,7 @@ instance (Waveform (RTree d1 a), Waveform a, d ~ d1 + 1, KnownNat d, KnownNat d1
       , preco = 11
       , subs = [("left",tsub),("right",tsub)]
       }
-    where tsub = tRef (Proxy @(RTree d1 a))
+    where tsub = tRef @(RTree d1 a)
 ```
 
 > Note: it would be a bit more efficient to use `TArray` here; however, we would not be able to

--- a/docs/howto/GADTS.md
+++ b/docs/howto/GADTS.md
@@ -20,7 +20,7 @@ This is the `Waveform` instance for `Vec` inside `Clash.Shockwaves.Internal.Wave
 
 ```hs
 instance (KnownNat n, Waveform a) => Waveform (Vec n a) where
-  translator = Translator (width @(Vec n a)) $ if natVal (Proxy @n) /= 0 then
+  translator = Translator (bitSize @(Vec n a)) $ if natVal (Proxy @n) /= 0 then
     TArray
       { start = ""
       , sep = " :> "

--- a/docs/howto/WAVEFORM.md
+++ b/docs/howto/WAVEFORM.md
@@ -178,7 +178,7 @@ configuration is possible. For example, `Maybe a` would by default get a transla
 like this:
 
 ```hs
-translator = Translator (width @(Maybe a)) $ TSum
+translator = Translator (bitSize @(Maybe a)) $ TSum
   [ tDup "Nothing" $ Translator 0 $ TConst $ Translation (Just ("Nothing",_,11)) []
   , tDup "Just" $ _ $ TProduct
       { subs = [(Just "0", tRef @a)] 
@@ -200,7 +200,7 @@ But instead, to reduce unnecessary subsignal clutter, it looks like this:
 ```hs
 translator = Translator _ $ TSum
   [ Translator 0 $ TConst $ Translation (Just ("Nothing","$maybe_nothing",11)) []
-  , Translator (width @a) $ TProduct
+  , Translator (bitSize @a) $ TProduct
       { subs = [(Just "Just.0", tRef @a)] 
       , start = "Just ", sep = "", stop = "", labels = []
       , preci = 10, preco = 10

--- a/docs/howto/WAVEFORM.md
+++ b/docs/howto/WAVEFORM.md
@@ -13,7 +13,7 @@ First, let's go through the functions and see what we need to do:
   instance meant to be used as a `derive via`. In that case, use:
   ```hs
   instance Waveform (WaveformForX a) where
-    typeName = typeNameP (Proxy @a)
+    typeName = defaultTypeName @a
   ```
 - `styles` is for adding constructor styles, and will likely go
   unused in a fully custom instance. For a guide on
@@ -137,7 +137,7 @@ If you have a subvalue that needs to be translated, do not include its full tran
 but include a reference to the type using `TRef`. Instead of manually creating this value,
 use the `tRef` function to create the full translator:
 ```hs
-translator = tRef (Proxy @MyType)
+translator = tRef @MyType
 ```
 
 #### Numbers
@@ -181,7 +181,7 @@ like this:
 translator = Translator (width @(Maybe a)) $ TSum
   [ tDup "Nothing" $ Translator 0 $ TConst $ Translation (Just ("Nothing",_,11)) []
   , tDup "Just" $ _ $ TProduct
-      { subs = [(Just "0", tRef (Proxy @a))] 
+      { subs = [(Just "0", tRef @a)] 
       , start = "Just ", sep = "", stop = "", labels = []
       , preci = 10, preco = 10
       , style = 0 }]
@@ -201,7 +201,7 @@ But instead, to reduce unnecessary subsignal clutter, it looks like this:
 translator = Translator _ $ TSum
   [ Translator 0 $ TConst $ Translation (Just ("Nothing","$maybe_nothing",11)) []
   , Translator (width @a) $ TProduct
-      { subs = [(Just "Just.0", tRef (Proxy @a))] 
+      { subs = [(Just "Just.0", tRef @a)] 
       , start = "Just ", sep = "", stop = "", labels = []
       , preci = 10, preco = 10
       , style = 0 }]


### PR DESCRIPTION
Fixes #111

Remove `Proxy` from the API (#111). Also rename `typeNameP` to `defaultTypeName` and make it public.
Rename `bitsize` to `bitSize` (which has a collision with `Bits`'s `bitSize` but oh well) and make it public.
Depricate `width` in `Waveform` for `bitSize`. Translators must always have the same width as their type.