### PR TITLE
Error is the translator width does not match the bitSize

### DIFF
--- a/changelog/entries/2026-06-04_T23:06:59_bitsize_neq_width_err.md
+++ b/changelog/entries/2026-06-04_T23:06:59_bitsize_neq_width_err.md
@@ -1,0 +1,9 @@
+---
+issues: [126]
+---
+
+# CHANGED
+To prevent issues, the translators specified for types must consume the same number of bits
+as are used to represent the data (as specified by `BitSize`).
+`tRef` now includes a check for this,
+which prevents types with incorrect widths both from being referenced and used directly.

--- a/clash-shockwaves/src/Clash/Shockwaves/Internal/Waveform.hs
+++ b/clash-shockwaves/src/Clash/Shockwaves/Internal/Waveform.hs
@@ -89,7 +89,10 @@ provided subsignal name.
 tDup :: SubSignal -> Translator -> Translator
 tDup name (Translator w t) = Translator w $ TDuplicate name (Translator w t)
 
--- | Generate a translator reference for a type.
+{- | Generate a translator reference for a type.
+Also checks whether the translator width matches the value of 'bitSize' for
+the type: if not, the function errors.
+-}
 tRef :: forall a. (Waveform a) => Translator
 tRef
   | w == bitSize @a =

--- a/clash-shockwaves/src/Clash/Shockwaves/Internal/Waveform.hs
+++ b/clash-shockwaves/src/Clash/Shockwaves/Internal/Waveform.hs
@@ -91,15 +91,23 @@ tDup name (Translator w t) = Translator w $ TDuplicate name (Translator w t)
 
 -- | Generate a translator reference for a type.
 tRef :: forall a. (Waveform a) => Translator
-tRef =
-  Translator (bitSize @a)
-    $ TRef
-      (typeName @a)
-      TypeRef
-        { translateBinRef = translateBin @a
-        , translatorRef = translator @a
-        , structureRef = structure @a
-        }
+tRef
+  | w == bitSize @a =
+      Translator (bitSize @a)
+        $ TRef
+          (typeName @a)
+          TypeRef
+            { translateBinRef = translateBin @a
+            , translatorRef = translator @a
+            , structureRef = structure @a
+            }
+  | otherwise =
+      error
+        $ "The Translator width and BitSize for type "
+        <> show (typeName @a)
+        <> " do not match."
+ where
+  Translator w _ = translator @a
 
 -- | Create a constant translator that consumes 0 bits and has no subsignals.
 tConst :: Render -> Translator

--- a/docs/howto/WAVEFORM.md
+++ b/docs/howto/WAVEFORM.md
@@ -29,6 +29,11 @@ file. A `Translator` consists of two values: a width, denoting the number of bit
 is expected to receive, and a a `TranslatorVariant` that actually describes how these bits
 are to be interpreted. There are many variants to choose from which are discussed below.
 
+> **Note:** It is important that the translator associated with a type consumes
+> the exact number of bits used to represent this type, as other types using this
+> translator assume the translation consumes the appropriate number of bits.
+> If a custom implementation does not obey this equality, the type cannot be traced
+> or referenced, and an error is produced instead.
 
 
 #### Constant values


### PR DESCRIPTION
If a translator does not consume the number of bits expected for that type (by `BitSize`), it may cause problems in the translators of other types that reference this translator. This PR adds a check to `tRef`, which is used to reference types, but also to add the types of signals directly.

Note that `tRef` already produced a translator with width `bitSize @a`, and so any types with the incorrect translator width would, when referenced, already be "fixed" (it might produce an unexpected translation a the single value, but not cause a shift in the alignment of other values in a product type, for example), but this is now an explicit check instead of rather opaque behavior.

Note that there shouldn't be a good reason to use a different number of bits, and if some bits must be dropped, there is always `ChangeBits`.

Fixes #126 