### PR TITLE
Remove parameter from `translators_config_dir`

### DIFF
--- a/surfer-shockwaves/src/plugin.rs
+++ b/surfer-shockwaves/src/plugin.rs
@@ -47,7 +47,7 @@ lazy_static! {
 pub fn new() -> FnResult<()> {
     info!("SHOCKWAVES: Created plugin");
 
-    let dir = unsafe { translators_config_dir(()) };
+    let dir = unsafe { translators_config_dir() };
     if let Ok(Json(Some(dir))) = dir {
         let dir = Utf8PathBuf::from(&dir);
         info!("SHOCKWAVES: Config dir: {dir:?}");
@@ -229,5 +229,5 @@ pub fn read_style_file(file: String) -> Option<Table> {
 extern "ExtismHost" {
     pub fn read_file(filename: String) -> Vec<u8>;
     pub fn file_exists(filename: String) -> bool;
-    pub fn translators_config_dir(_user_data: ()) -> Json<Option<String>>;
+    pub fn translators_config_dir() -> Json<Option<String>>;
 }


### PR DESCRIPTION
When using the plugin, I encountered the following error in Surfer's logs:

```
ERROR libsurfer: Failed to load wasm translator Failed to load plugin from /home/jochem/.local/share/surfer/translators/surfer_shockwaves.wasm incompatible import type for `extism:host/user::translators_config_dir`
```

This is because the signature of the `translators_config_dir` host function changed recently; this is the commit:

https://gitlab.com/surfer-project/surfer/-/commit/2cca79312c0fe37640bda84fad6b9d1e7850c8c2

This commit updates the Shockwaves plugin to use the new `translators_config_dir` signature.